### PR TITLE
Scala 2.11 cross build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
 language: scala
-scala:
-  - 2.10.3
+jdk:
+  - oraclejdk7
+  - openjdk7
+script:
+  - sbt +test

--- a/build.sbt
+++ b/build.sbt
@@ -13,28 +13,26 @@ organization := "com.stackmob"
 
 scalaVersion := "2.10.4"
 
-scalacOptions := Seq("-unchecked", "-deprecation", "-feature")
+crossScalaVersions := Seq("2.10.4", "2.11.4")
 
-resolvers ++= List(
-  "spray repo" at "http://repo.spray.io"
-)
+scalacOptions := Seq("-unchecked", "-deprecation", "-feature")
 
 libraryDependencies ++= {
   val httpCoreVersion = "4.2.5"
   val httpClientVersion = "4.2.5"
   val scalaCheckVersion = "1.11.3"
   val specs2Version = "2.3.13"
-  val liftJsonVersion = "2.5.1"
-  val sprayVersion = "1.3.1"
-  val akkaVersion = "2.3.4"
+  val liftJsonVersion = "2.6-RC2"
+  val sprayVersion = "1.3.2"
+  val akkaVersion = "2.3.8"
   Seq(
     "org.scalaz" %% "scalaz-core" % "7.0.6",
     "org.apache.httpcomponents" % "httpcore" % httpCoreVersion,
     "org.apache.httpcomponents" % "httpclient" % httpClientVersion exclude("org.apache.httpcomponents", "httpcore"),
-    "io.spray" % "spray-client" % sprayVersion,
-    "io.spray" % "spray-caching" % sprayVersion,
+    "io.spray" %% "spray-client" % sprayVersion,
+    "io.spray" %% "spray-caching" % sprayVersion,
     "com.typesafe.akka" %% "akka-actor" % akkaVersion,
-    "com.twitter" %% "finagle-http" % "6.5.0" exclude("commons-codec", "commons-codec"),
+    "com.twitter" %% "finagle-http" % "6.24.1-MONOCACHE" exclude("commons-codec", "commons-codec"),
     "net.liftweb" %% "lift-json-scalaz7" % liftJsonVersion exclude ("org.scalaz", "scalaz-core_2.10"),
     "org.scalacheck" %% "scalacheck" % scalaCheckVersion % "test",
     "org.specs2" %% "specs2" % specs2Version % "test" exclude("org.parboiled", "parboiled-core")
@@ -48,6 +46,12 @@ conflictManager := ConflictManager.strict
 dependencyOverrides <+= (scalaVersion) { vsn => "org.scala-lang" % "scala-library" % vsn }
 
 dependencyOverrides <+= (scalaVersion) { vsn => "org.scala-lang" % "scala-compiler" % vsn }
+
+dependencyOverrides <+= (scalaVersion) { vsn => "org.scala-lang" % "scala-reflect" % vsn }
+
+dependencyOverrides += "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.2"
+
+dependencyOverrides += "org.scala-lang.modules" %% "scala-xml" % "1.0.2"
 
 logBuffered := false
 

--- a/build.sbt
+++ b/build.sbt
@@ -11,11 +11,9 @@ name := "newman"
 
 organization := "com.stackmob"
 
-scalaVersion := "2.10.3"
+scalaVersion := "2.10.4"
 
 scalacOptions := Seq("-unchecked", "-deprecation", "-feature")
-
-scalacOptions in Test ++= Seq("-Yrangepos")
 
 resolvers ++= List(
   "spray repo" at "http://repo.spray.io"
@@ -24,24 +22,22 @@ resolvers ++= List(
 libraryDependencies ++= {
   val httpCoreVersion = "4.2.5"
   val httpClientVersion = "4.2.5"
-  val scalaCheckVersion = "1.10.1"
-  val specs2Version = "2.2.3"
-  val mockitoVersion = "1.9.0"
+  val scalaCheckVersion = "1.11.3"
+  val specs2Version = "2.3.13"
   val liftJsonVersion = "2.5.1"
   val sprayVersion = "1.3.1"
   val akkaVersion = "2.3.4"
   Seq(
+    "org.scalaz" %% "scalaz-core" % "7.0.6",
     "org.apache.httpcomponents" % "httpcore" % httpCoreVersion,
     "org.apache.httpcomponents" % "httpclient" % httpClientVersion exclude("org.apache.httpcomponents", "httpcore"),
     "io.spray" % "spray-client" % sprayVersion,
     "io.spray" % "spray-caching" % sprayVersion,
     "com.typesafe.akka" %% "akka-actor" % akkaVersion,
     "com.twitter" %% "finagle-http" % "6.5.0" exclude("commons-codec", "commons-codec"),
-    "net.liftweb" %% "lift-json-scalaz7" % liftJsonVersion,
+    "net.liftweb" %% "lift-json-scalaz7" % liftJsonVersion exclude ("org.scalaz", "scalaz-core_2.10"),
     "org.scalacheck" %% "scalacheck" % scalaCheckVersion % "test",
-    "org.specs2" %% "specs2" % specs2Version % "test" exclude("org.scalaz", "scalaz-core_2.10"),
-    "org.pegdown" % "pegdown" % "1.2.1" % "test" exclude("org.parboiled", "parboiled-core"),
-    "org.mockito" % "mockito-all" % mockitoVersion % "test"
+    "org.specs2" %% "specs2" % specs2Version % "test" exclude("org.parboiled", "parboiled-core")
   )
 }
 
@@ -50,6 +46,8 @@ testOptions in Test += Tests.Argument("html", "console")
 conflictManager := ConflictManager.strict
 
 dependencyOverrides <+= (scalaVersion) { vsn => "org.scala-lang" % "scala-library" % vsn }
+
+dependencyOverrides <+= (scalaVersion) { vsn => "org.scala-lang" % "scala-compiler" % vsn }
 
 logBuffered := false
 
@@ -86,15 +84,11 @@ publishMavenStyle := true
 
 publishArtifact in Test := true
 
+homepage := Some(url("https://github.com/stackmob/newman"))
+
+licenses := Seq("Apache 2" -> url("http://www.apache.org/licenses/LICENSE-2.0.txt"))
+
 pomExtra := (
-  <url>https://github.com/stackmob/newman</url>
-  <licenses>
-    <license>
-      <name>Apache 2</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-      <distribution>repo</distribution>
-    </license>
-  </licenses>
   <scm>
     <url>git@github.com:stackmob/newman.git</url>
     <connection>scm:git:git@github.com:stackmob/newman.git</connection>

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.5
+sbt.version=0.13.7

--- a/src/main/scala/com/stackmob/newman/ApacheHttpClient.scala
+++ b/src/main/scala/com/stackmob/newman/ApacheHttpClient.scala
@@ -37,7 +37,7 @@ import ApacheHttpClient._
 import java.util.concurrent.atomic.AtomicInteger
 
 class ApacheHttpClient(val httpClient: org.apache.http.client.HttpClient)
-                      (implicit val requestContext: ExecutionContext = newmanRequestExecutionContext) extends HttpClient {
+                      (implicit val requestContext: ExecutionContext) extends HttpClient {
 
   def this(socketTimeout: Int = ApacheHttpClient.DefaultSocketTimeout,
            connectionTimeout: Int = ApacheHttpClient.DefaultConnectionTimeout,

--- a/src/main/scala/com/stackmob/newman/FinagleHttpClient.scala
+++ b/src/main/scala/com/stackmob/newman/FinagleHttpClient.scala
@@ -145,7 +145,7 @@ object FinagleHttpClient {
     def toNewmanHttpResponse: Option[HttpResponse] = {
       for {
         code <- HttpResponseCode.fromInt(resp.getStatus.getCode)
-        rawHeaders <- Option(resp.getHeaders)
+        rawHeaders <- Option(resp.headers)
         headers <- {
           val tupList = rawHeaders.asScala.map { entry =>
             entry.getKey -> entry.getValue

--- a/src/test/scala/com/stackmob/newman/test/URLBuilderDSLSpecs.scala
+++ b/src/test/scala/com/stackmob/newman/test/URLBuilderDSLSpecs.scala
@@ -54,7 +54,7 @@ class URLBuilderDSLSpecs extends Specification { def is =
           case _ => Nil
         }
       }.toList
-      expected must haveTheSameElementsAs(givenQueryList)
+      expected must containTheSameElementsAs(givenQueryList)
     }
   }
 

--- a/src/test/scala/com/stackmob/newman/test/client/ETagAwareApacheHttpClientSpecs.scala
+++ b/src/test/scala/com/stackmob/newman/test/client/ETagAwareApacheHttpClientSpecs.scala
@@ -63,7 +63,7 @@ class ETagAwareApacheHttpClientSpecs extends Specification { def is =
       HttpResponse(HttpResponseCode.NotModified, Headers.empty, body)
     }
 
-    protected lazy val client = new ETagAwareHttpClient(rawClient, responseCacher)
+    protected lazy val client = new ETagAwareHttpClient(rawClient, responseCacher)(SequentialExecutionContext)
 
     protected def rawClient: DummyHttpClient
     protected def responseCacher: HttpResponseCacher
@@ -81,7 +81,7 @@ class ETagAwareApacheHttpClientSpecs extends Specification { def is =
       val urlCorrect = rawClient.getRequests.get(0)._1 must beEqualTo(url)
       val headersCorrect = rawClient.getRequests.get(0)._2 must haveTheSameHeadersAs(Headers(INM, eTag))
       val foldRes = responseCacher.verifyFoldCalls { list =>
-        list must haveTheSameElementsAs(req :: Nil)
+        list must containTheSameElementsAs(req :: Nil)
       }
 
       val applyRes = responseCacher.verifyApplyCalls { list =>
@@ -123,7 +123,7 @@ class ETagAwareApacheHttpClientSpecs extends Specification { def is =
         list must beEmpty
       }
       val foldCallRes = responseCacher.verifyFoldCalls { list =>
-        list must haveTheSameElementsAs(req :: Nil)
+        list must containTheSameElementsAs(req :: Nil)
       }
 
       applyCallRes and foldCallRes
@@ -139,7 +139,7 @@ class ETagAwareApacheHttpClientSpecs extends Specification { def is =
       }
 
       val foldCallRes = responseCacher.verifyFoldCalls { list =>
-        list must haveTheSameElementsAs(req :: Nil)
+        list must containTheSameElementsAs(req :: Nil)
       }
 
       applyCallRes and foldCallRes
@@ -154,7 +154,7 @@ class ETagAwareApacheHttpClientSpecs extends Specification { def is =
       val req = client.get(url, Headers.empty)
       req.block()
       val foldRes = responseCacher.verifyFoldCalls { list =>
-        list must haveTheSameElementsAs(req :: Nil)
+        list must containTheSameElementsAs(req :: Nil)
       }
       val applyRes = responseCacher.verifyApplyCalls { list =>
         list must beEmpty
@@ -166,7 +166,7 @@ class ETagAwareApacheHttpClientSpecs extends Specification { def is =
       val req = client.get(url, Headers.empty)
       req.block()
       val foldRes = responseCacher.verifyFoldCalls { list =>
-        list must haveTheSameElementsAs(req :: Nil)
+        list must containTheSameElementsAs(req :: Nil)
       }
       val applyRes = responseCacher.verifyApplyCalls { list =>
         list must beEmpty
@@ -187,7 +187,7 @@ class ETagAwareApacheHttpClientSpecs extends Specification { def is =
       fromTryCatch(req.block())
 
       val foldRes = responseCacher.verifyFoldCalls { list =>
-        list must haveTheSameElementsAs(req :: Nil)
+        list must containTheSameElementsAs(req :: Nil)
       }
 
       val applyRes = responseCacher.verifyApplyCalls { list =>

--- a/src/test/scala/com/stackmob/newman/test/client/ReadCachingDummyHttpClientSpecs.scala
+++ b/src/test/scala/com/stackmob/newman/test/client/ReadCachingDummyHttpClientSpecs.scala
@@ -61,7 +61,7 @@ class ReadCachingDummyHttpClientSpecs extends Specification with ScalaCheck { de
     forAll(genURL,
       genHeaders,
       genDummyHttpClient,
-      genDummyHttpResponseCache(genOnApply, Gen.value(Right(())))) { (url, headers, dummyClient, dummyCache) =>
+      genDummyHttpResponseCache(genOnApply, Gen.const(Right(())))) { (url, headers, dummyClient, dummyCache) =>
 
       val client = new ReadCachingHttpClient(dummyClient, dummyCache)
 
@@ -81,7 +81,7 @@ class ReadCachingDummyHttpClientSpecs extends Specification with ScalaCheck { de
     forAll(genURL,
       genHeaders,
       genDummyHttpClient,
-      genDummyHttpResponseCache(Gen.value(Right(())), Gen.value(Right(())))) { (url, headers, dummyClient, dummyCache) =>
+      genDummyHttpResponseCache(Gen.const(Right(())), Gen.const(Right(())))) { (url, headers, dummyClient, dummyCache) =>
 
       val client = new ReadCachingHttpClient(dummyClient, dummyCache)
 
@@ -118,7 +118,7 @@ class ReadCachingDummyHttpClientSpecs extends Specification with ScalaCheck { de
       genHeaders,
       genRawBody,
       genDummyHttpClient,
-      genDummyHttpResponseCache(Gen.value(Right(())), Gen.value(Right(())))) { (url, headers, body, dummyClient, dummyCache) =>
+      genDummyHttpResponseCache(Gen.const(Right(())), Gen.const(Right(())))) { (url, headers, body, dummyClient, dummyCache) =>
       val client = new ReadCachingHttpClient(dummyClient, dummyCache)
 
       val postRes = client.post(url, headers, body).block() must beEqualTo(dummyClient.responseToReturn.block())

--- a/src/test/scala/com/stackmob/newman/test/dsl/AsyncResponseHandlerDSLSpecs.scala
+++ b/src/test/scala/com/stackmob/newman/test/dsl/AsyncResponseHandlerDSLSpecs.scala
@@ -40,6 +40,7 @@ class AsyncResponseHandlerDSLSpecs extends Specification { def is =
   end
 
   import com.stackmob.newman.concurrent.SequentialExecutionContext
+  override val concurrentExecutionContext: ExecutionContext = SequentialExecutionContext
 
   private trait Context {
     //we need to wait longer than the default to account for scheduling the map function inside AsyncResponseHandlerDSL's default method

--- a/src/test/scala/com/stackmob/newman/test/finagle/RichNettyHttpResponseSpecs.scala
+++ b/src/test/scala/com/stackmob/newman/test/finagle/RichNettyHttpResponseSpecs.scala
@@ -40,7 +40,7 @@ class RichNettyHttpResponseSpecs extends Specification with ScalaCheck { def is 
       val (_, headers, _, nettyResp) = tup
       nettyResp.toNewmanHttpResponse must beSome.like {
         case resp: HttpResponse => resp.headers must beSome.like {
-          case headerList => headerList.list.toMap must haveTheSameElementsAs(headers)
+          case headerList => headerList.list.toMap must beEqualTo(headers)
         }
       }
     }

--- a/src/test/scala/com/stackmob/newman/test/finagle/package.scala
+++ b/src/test/scala/com/stackmob/newman/test/finagle/package.scala
@@ -16,7 +16,7 @@ import com.stackmob.newman.FinagleHttpClient.RichRawBody
  */
 package object finagle {
   lazy val genHttpResponseStatus: Gen[HttpResponseStatus] = {
-    Gen.value(HttpResponseStatus.OK)
+    Gen.const(HttpResponseStatus.OK)
   }
 
   lazy val genNonEmptyString: Gen[String] = Gen.alphaStr.suchThat { s =>
@@ -33,14 +33,14 @@ package object finagle {
   }
 
   lazy val genHeaders: Gen[Map[String, String]] = {
-    Gen.listOf1(genHeader).map { list =>
+    Gen.nonEmptyListOf(genHeader).map { list =>
       list.toMap
     }
   }
 
   lazy val genByteArray: Gen[Array[Byte]] = {
     val genByte = Arbitrary.arbitrary[Byte]
-    Gen.listOf1(genByte).map { list =>
+    Gen.nonEmptyListOf(genByte).map { list =>
       list.toArray
     }
   }

--- a/src/test/scala/com/stackmob/newman/test/finagle/package.scala
+++ b/src/test/scala/com/stackmob/newman/test/finagle/package.scala
@@ -60,7 +60,7 @@ package object finagle {
       val resp = new DefaultHttpResponse(HttpVersion.HTTP_1_1, status)
       headers.foreach { tup =>
         val (headerName, headerValue) = tup
-        resp.setHeader(headerName, headerValue)
+        resp.headers().set(headerName, headerValue)
       }
       resp.setContent(body)
       (status, headers, body, resp)

--- a/src/test/scala/com/stackmob/newman/test/request/HttpRequestExecutionSpecs.scala
+++ b/src/test/scala/com/stackmob/newman/test/request/HttpRequestExecutionSpecs.scala
@@ -106,11 +106,11 @@ class HttpRequestExecutionSpecs extends Specification { def is =
       val requestList = List(request1, throwingRequest)
       val res = concurrentRequests(requestList)
 
-      val oneThrows = res must haveOneElementLike {
-        case tup => tup._2.toEither() must beLeft
+      val oneThrows = res must contain {
+        tup: (HttpRequest, Future[HttpResponse]) => tup._2.toEither() must beLeft
       }
-      val oneSucceeds = res must haveOneElementLike {
-        case tup => tup._2.toEither() must beRight
+      val oneSucceeds = res must contain {
+        tup: (HttpRequest, Future[HttpResponse]) => tup._2.toEither() must beRight
       }
       oneThrows and oneSucceeds
     }

--- a/src/test/scala/com/stackmob/newman/test/response/serialization/HttpResponseSerializationSpecs.scala
+++ b/src/test/scala/com/stackmob/newman/test/response/serialization/HttpResponseSerializationSpecs.scala
@@ -44,7 +44,7 @@ class HttpResponseSerializationSpecs extends Specification { def is =
         succ = { deserialized: HttpResponse =>
           (deserialized.code must beEqualTo(resp.code)) and
           (deserialized.headers must haveTheSameHeadersAs(resp.headers)) and
-          (deserialized.rawBody.toList must haveTheSameElementsAs(resp.rawBody.toList))
+          (deserialized.rawBody.toList must containTheSameElementsAs(resp.rawBody.toList))
         },
         fail = { e =>
           SpecsFailure("deserialization failed with error %s".format(e.toString()))

--- a/src/test/scala/com/stackmob/newman/test/scalacheck/package.scala
+++ b/src/test/scala/com/stackmob/newman/test/scalacheck/package.scala
@@ -30,7 +30,7 @@ import scala.concurrent.Future
 import com.stackmob.newman.test.caching.DummyHttpResponseCacher
 
 package object scalacheck {
-  private[test] lazy val genNonEmptyString: Gen[String] = Gen.listOf1(Gen.alphaChar).map(_.mkString)
+  private[test] lazy val genNonEmptyString: Gen[String] = Gen.nonEmptyListOf(Gen.alphaChar).map(_.mkString)
 
   private[test] lazy val timeUnits = Seq[TimeUnit](TimeUnit.DAYS,
     TimeUnit.HOURS,
@@ -161,7 +161,7 @@ package object scalacheck {
   }
 
   private[test] def genNoneOption[T]: Gen[Option[T]] = {
-    Gen.value[Option[T]](Option.empty[T])
+    Gen.const[Option[T]](Option.empty[T])
   }
 
   private[test] def genDummyHttpResponseCache(genApplyBehavior: Gen[Either[Future[HttpResponse], Unit]], genFoldBehavior: Gen[Either[Future[HttpResponse], Unit]]): Gen[DummyHttpResponseCacher] = {


### PR DESCRIPTION
finagle-http now has a 2.11 published version so 2.11 cross build support is simple

fixes #109